### PR TITLE
Add support for acl header

### DIFF
--- a/s3/index.js
+++ b/s3/index.js
@@ -247,6 +247,10 @@ Connection.prototype.createObject = function(options, content, callback) {
                 headers[`x-amz-meta-${name}`] = options.meta[name];
             }
         }
+	    
+	if (options.acl) {
+            headers[`x-amz-acl`] = options.acl;
+        }
 
         this.agent.put(urlname, headers, content, (err, response) => {
             if (!err && ![ 200, 204 ].includes(response.statusCode)) {


### PR DESCRIPTION
Currently there's no way to set the x-amz-acl header. I'm using your library in a use case where I need to set the acl of some objects.