### PR TITLE
'content-length' HTTP header added to createObject operation

### DIFF
--- a/docs/connection.md
+++ b/docs/connection.md
@@ -265,6 +265,9 @@ So far, *options* accepts following properties:
 *	__options.contentType__ *string* OPTIONAL  
 	MIME value.
 
+*       __options.contentLength__ *int* OPTIONAL
+        Object's size in bytes.
+
 *	__options.name__ *string*  
 	Object name.
 

--- a/s3/Connection.js
+++ b/s3/Connection.js
@@ -323,18 +323,19 @@ Connection.prototype.createBucket = function(options, callback) {
 /**
  * Put an object to remote storage.
  * @param  {Object}           options
- * @param  {string}           options               regard as the name(key) of object to be stored
- * @param  {string}           options.name          name(key) of object to be stored
- * @param  {object}          [options.meta]         meta info of the object
- * @param  {string}          [options.metaFlag]     'w' | 'a'
- * @param  {string}          [options.contentType]  content type (MIME value)
- * @param  {string}          [options.acl]          [EXPERIMENTAL] acl of the object
- * @param  {string}          [options.bucket]       container/bucket to place the object, 
- *                                                  by default current container of the connection will be used
- * @param  {string}           content               object content text
- * @param  {stream.Readable}  content               object content stream
- * @param  {Buffer}           content               object content buffer
- * @param  {Function}        [callback]             function(err, data)
+ * @param  {string}           options                 regard as the name(key) of object to be stored
+ * @param  {string}           options.name            name(key) of object to be stored
+ * @param  {object}          [options.meta]           meta info of the object
+ * @param  {string}          [options.metaFlag]       'w' | 'a'
+ * @param  {string}          [options.contentType]    content type (MIME value)
+ * @param  {int}             [options.contentLength]  content length in bytes
+ * @param  {string}          [options.acl]            [EXPERIMENTAL] acl of the object
+ * @param  {string}          [options.bucket]         container/bucket to place the object, 
+ *                                                    by default current container of the connection will be used
+ * @param  {string}           content                 object content text
+ * @param  {stream.Readable}  content                 object content stream
+ * @param  {Buffer}           content                 object content buffer
+ * @param  {Function}        [callback]               function(err, data)
  * 
  * This function maybe used to change existing object's meta info.
  * In this case, no content will be put. 
@@ -360,6 +361,9 @@ Connection.prototype.createObject = function(options, content, callback) {
         
         let urlname = this._encodeUrl([options.bucket, options.name]);
         let headers = this._formatHeaders(options);
+        if (options.contentLength) {
+            headers['content-length'] = options.contentLength;
+        }
         
         // By default, use method PUT to create(upload) a new object.
         let method = 'put';


### PR DESCRIPTION
S3-compatible storage MinIO (https://min.io/) requires "Content-Length" HTTP header in order to be able to put object in bucket. Otherwise it returns HTTP 411:
<img width="1424" alt="Screen Shot 2020-07-24 at 14 52 48" src="https://user-images.githubusercontent.com/16934641/88391892-b78cdb80-cdc3-11ea-986c-5ac4e98f2f0f.png">